### PR TITLE
changed HandSoldering 3D paths

### DIFF
--- a/R_0603_HandSoldering.kicad_mod
+++ b/R_0603_HandSoldering.kicad_mod
@@ -16,7 +16,7 @@
   (fp_line (start -0.5 -0.675) (end 0.5 -0.675) (layer F.SilkS) (width 0.15))
   (pad 1 smd rect (at -1.1 0) (size 1.2 0.9) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 1.1 0) (size 1.2 0.9) (layers F.Cu F.Paste F.Mask))
-  (model Resistors_SMD/R_0603_HandSoldering.wrl
+  (model Resistors_SMD/R_0603.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/R_0805_HandSoldering.kicad_mod
+++ b/R_0805_HandSoldering.kicad_mod
@@ -16,7 +16,7 @@
   (fp_line (start -0.6 -0.875) (end 0.6 -0.875) (layer F.SilkS) (width 0.15))
   (pad 1 smd rect (at -1.35 0) (size 1.5 1.3) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 1.35 0) (size 1.5 1.3) (layers F.Cu F.Paste F.Mask))
-  (model Resistors_SMD/R_0805_HandSoldering.wrl
+  (model Resistors_SMD/R_0805.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/R_1206_HandSoldering.kicad_mod
+++ b/R_1206_HandSoldering.kicad_mod
@@ -16,7 +16,7 @@
   (fp_line (start -1 -1.075) (end 1 -1.075) (layer F.SilkS) (width 0.15))
   (pad 1 smd rect (at -2 0) (size 2 1.7) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 2 0) (size 2 1.7) (layers F.Cu F.Paste F.Mask))
-  (model Resistors_SMD/R_1206_HandSoldering.wrl
+  (model Resistors_SMD/R_1206.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/R_1210_HandSoldering.kicad_mod
+++ b/R_1210_HandSoldering.kicad_mod
@@ -16,7 +16,7 @@
   (fp_line (start -1 -1.475) (end 1 -1.475) (layer F.SilkS) (width 0.15))
   (pad 1 smd rect (at -2 0) (size 2 2.5) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 2 0) (size 2 2.5) (layers F.Cu F.Paste F.Mask))
-  (model Resistors_SMD/R_1210_HandSoldering.wrl
+  (model Resistors_SMD/R_1210.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/R_1218_HandSoldering.kicad_mod
+++ b/R_1218_HandSoldering.kicad_mod
@@ -16,7 +16,7 @@
   (fp_line (start -0.95 -2.675) (end 0.95 -2.675) (layer F.SilkS) (width 0.15))
   (pad 1 smd rect (at -1.95 0) (size 2 4.9) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 1.95 0) (size 2 4.9) (layers F.Cu F.Paste F.Mask))
-  (model Resistors_SMD/R_1218_HandSoldering.wrl
+  (model Resistors_SMD/R_1218.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/R_2010_HandSoldering.kicad_mod
+++ b/R_2010_HandSoldering.kicad_mod
@@ -16,7 +16,7 @@
   (fp_line (start -1.95 -1.475) (end 1.95 -1.475) (layer F.SilkS) (width 0.15))
   (pad 1 smd rect (at -3.15 0) (size 2.4 2.5) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 3.15 0) (size 2.4 2.5) (layers F.Cu F.Paste F.Mask))
-  (model Resistors_SMD/R_2010_HandSoldering.wrl
+  (model Resistors_SMD/R_2010.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/R_2512_HandSoldering.kicad_mod
+++ b/R_2512_HandSoldering.kicad_mod
@@ -16,7 +16,7 @@
   (fp_line (start -2.6 -1.825) (end 2.6 -1.825) (layer F.SilkS) (width 0.15))
   (pad 1 smd rect (at -3.95 0) (size 2.7 3.2) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 3.95 0) (size 2.7 3.2) (layers F.Cu F.Paste F.Mask))
-  (model Resistors_SMD/R_2512_HandSoldering.wrl
+  (model Resistors_SMD/R_2512.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
changed `*_HandSoldering.kicad_mod` 3D paths to use 'normal' 3D
packages (https://github.com/KiCad/kicad-library/tree/master/modules/packages3d/Resistors_SMD)
